### PR TITLE
feat(fuzzy-theme): align Breadcrumb bar colors

### DIFF
--- a/themes/FuZZy Theme-color-theme.json
+++ b/themes/FuZZy Theme-color-theme.json
@@ -13,11 +13,18 @@
 		"activityBarBadge.background": "#fa8500",
 		"activityBarBadge.foreground": "#ececec",
 
-    // Badge & Banner
+    // Badge and Banner
     "badge.background": "#fa8500",
     "badge.foreground": "#ececec",
 		"banner.background": "#fa8500",
 		"banner.foreground": "#ececec",
+
+    // Breadcrumb
+		"breadcrumb.activeSelectionForeground": "#fa8500",
+		"breadcrumb.background": "#ececec",
+		"breadcrumb.focusForeground": "#22282b",
+		"breadcrumb.foreground": "#252526",
+		"breadcrumbPicker.background": "#ececec",
 
     // Panel
     "panelTitle.activeBorder": "#fa8500",


### PR DESCRIPTION
Breadcrumb bar colors are different from what is intended.
This addresses the issue.